### PR TITLE
Fix all tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.5'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -58,8 +58,9 @@ function load_module(root::Module, path::String)
 end
 
 function load_module_from_main(path)
-    file_module_sym = Symbol(path)    
-    if haskey(loaded_path, path)
+    file_module_sym = Symbol(path)
+    # always reload file when it's in interactive mode and in Main
+    if haskey(loaded_path, path) && !isinteractive()
         return loaded_path[path]
     else
         file_module = Base.eval(Base.__toplevel__, :(module $(file_module_sym) end))

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -16,7 +16,7 @@ function from_m(m::Module, path::String, ex::Expr)
     if !isabspath(path) && (pathof(m) !== nothing)
         path = joinpath(dirname(pathof(m)), path)
     else
-        path = abspath(normpath(path))
+        path = abspath(path)
     end
 
     loading = Expr(ex.head)
@@ -78,7 +78,7 @@ function load_module_from_main(path)
 end
 
 function load_module_from_package(root, path)
-    toplevel_symbol = Symbol("#__toplevel__#")
+    toplevel_symbol = Symbol("#__imports__#")
     file_module_sym = Symbol(relpath(path, pathof(root)))
     if isdefined(root, toplevel_symbol) # package
         toplevel = getfield(root, toplevel_symbol)

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -40,9 +40,9 @@ function from_m(m::Module, path::String, ex::Expr)
         end
     end
 
-    if root === Main && !isdefined(Main, Symbol(path))
+    if root === Main && (isinteractive() || !isdefined(Main, Symbol(path)))
         return quote
-            const $(Symbol(path)) = $file_module
+            $(Symbol(path)) = $file_module
             $loading
         end
     end

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -40,9 +40,9 @@ function from_m(m::Module, path::String, ex::Expr)
         end
     end
 
-    if root === Main && (isinteractive() || !isdefined(Main, Symbol(path)))
+    if root === Main && !isdefined(Main, Symbol(path))
         return quote
-            $(Symbol(path)) = $file_module
+            const $(Symbol(path)) = $file_module
             $loading
         end
     end
@@ -59,8 +59,7 @@ end
 
 function load_module_from_main(path)
     file_module_sym = Symbol(path)
-    # always reload file when it's in interactive mode and in Main
-    if haskey(loaded_path, path) && !isinteractive()
+    if haskey(loaded_path, path)
         return loaded_path[path]
     else
         file_module = Base.eval(Base.__toplevel__, :(module $(file_module_sym) end))

--- a/test/file.jl
+++ b/test/file.jl
@@ -4,6 +4,7 @@ export foo
 using Test
 
 function foo()
+    println()
     @test true
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -7,4 +7,12 @@ function foo()
     @test true
 end
 
+end # module A
+
+module B
+
+export should_not_appear
+function should_not_appear()
 end
+
+end # module B

--- a/test/file.jl
+++ b/test/file.jl
@@ -1,7 +1,10 @@
 module A
 
+export foo
+using Test
+
 function foo()
-    println("hello")
+    @test true
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,7 @@ const project_path = dirname(dirname(pathof(FromFile)))
 
 @testset "Main using A" begin
     @test fullname(A) == (Symbol(abspath(joinpath(project_path, "test", "file.jl"))), :A)
+    @test isdefined(@__MODULE__, :foo)
+    @test !isdefined(@__MODULE__, :should_not_appear)
     foo()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,16 @@
 using FromFile
 using Test
 
+# to make test consistent in Pkg.test() and include("test/runtests.jl")
+cwd = pwd()
+cd(joinpath(dirname(dirname(pathof(FromFile))), "test"))
+
 module wrapper1
 	using FromFile
 	visible = [:A]
 	invisible = [:foo, :bar, :baz, :quux, :B, :C]
 	
-    @from "test/file.jl" import A
+    @from "file.jl" import A
 end
 
 module wrapper2
@@ -14,7 +18,7 @@ module wrapper2
 	visible = [:foo]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-	@from "test/file.jl" import A: foo
+	@from "file.jl" import A: foo
 end
 
 module wrapper3
@@ -22,7 +26,7 @@ module wrapper3
 	visible = [:foo, :B]
 	invisible = [:bar, :baz, :quux, :A, :C]
 	
-	@from "test/file.jl" import A: foo, B
+	@from "file.jl" import A: foo, B
 end
 
 module wrapper4
@@ -30,15 +34,15 @@ module wrapper4
 	visible = [:foo]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-    @from "test/file.jl" import A.foo
+    @from "file.jl" import A.foo
 end
 
 module wrapper5
 	using FromFile
 	visible = [:foo, :B]
-	invisible = [:bar, :baz, :quux, :A, :B, :C]
+	invisible = [:bar, :baz, :quux, :A, :C]
 	
-    @from "test/file.jl" import A.foo, A.B
+	@from "file.jl" import A.foo, A.B
 end
 
 module wrapper6
@@ -46,7 +50,7 @@ module wrapper6
 	visible = [:A, :foo, :B]
 	invisible = [:bar, :baz, :quux, :C]
 	
-	@from "test/file.jl" using A
+	@from "file.jl" using A
 end
 
 module wrapper7
@@ -54,7 +58,7 @@ module wrapper7
 	visible = [:foo]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-	@from "test/file.jl" using A: foo
+	@from "file.jl" using A: foo
 end
 
 module wrapper8
@@ -62,7 +66,7 @@ module wrapper8
 	visible = [:foo, :B]
 	invisible = [:bar, :baz, :quux, :A, :C]
 	
-	@from "test/file.jl" using A: foo, B
+	@from "file.jl" using A: foo, B
 end
 
 module wrapper9
@@ -70,7 +74,7 @@ module wrapper9
 	visible = [:A, :C]
 	invisible = [:foo, :bar, :baz, :quux, :B]
 	
-    @from "test/file.jl" import A, C
+    @from "file.jl" import A, C
 end
 
 module wrapper10
@@ -78,7 +82,7 @@ module wrapper10
 	visible = [:foo, :quux, :A, :B, :C]
 	invisible = [:bar, :baz]
 	
-    @from "test/file.jl" using A, C
+    @from "file.jl" using A, C
 end
 
 @testset "Tests from REPL" begin
@@ -103,6 +107,7 @@ end
 	# Make sure that the import modules are where we expect them to be
 	project_path = dirname(dirname(pathof(FromFile)))
 	file_symbol = Symbol(abspath(joinpath(project_path, "test", "file.jl")))
-	@test fullname(wrapper1.A) == (:FromFile, :__toplevel__, file_symbol, :A)
-	@test isdefined(FromFile.__toplevel__, file_symbol)
+	@test fullname(wrapper1.A) == (file_symbol, :A)
 end
+
+cd(cwd)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,9 @@ using Test
 
 @from "test/file.jl" using A
 
-path = abspath("test/file.jl")
-m = getfield(From.__toplevel__, Symbol(path))
+const project_path = dirname(dirname(pathof(FromFile)))
+
+@testset "Main using A" begin
+    @test fullname(A) == (Symbol(abspath(joinpath(project_path, "test", "file.jl"))), :A)
+    foo()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using FromFile
 using Test
 
 @from "test/file.jl" using A
+@from "test/file.jl" import B
 
 const project_path = dirname(dirname(pathof(FromFile)))
 


### PR DESCRIPTION
So let me explain what happens,

current implementation evaluate the file imported to `Main` in `From.__toplevel__` then generate a module for import which is the module of `filepath`. However, this module is not in the environment specification, so now Julia will error because the expression we generated looks like following

```julia
using var"path/to/file.jl".A
```

as a result, this does not work in REPL (it's fine for packages since the file module in the package is a submodule of the package module). So one way to work around this is to create a binding to the file module in `Main` then do a local `using` on it.

cc: @patrick-kidger 