### PR TITLE
Fixes for paths; importing in packages due to closed modules

### DIFF
--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -2,33 +2,38 @@ module FromFile
 
 export @from
 
-# This replicates Base.__toplevel__
-baremodule __toplevel__
-    using Base
+macro from(path::String, ex::Expr)
+    esc(from_m(__module__, __source__, path, ex))
 end
 
-macro from(path::String, ex)
-    esc(from_m(__module__, path, ex))
-end
-
-function from_m(m::Module, path::String, ex::Expr)
+function from_m(m::Module, s::LineNumberNode, path::String, ex::Expr)
     ex.head === :using || ex.head === :import || error("expect using/import statement")
-    path = abspath(normpath(path))
-    loading = Expr(ex.head)
-    root = root_module(m)
-
-    if root === Main
-        toplevel = __toplevel__
+	
+	root = Base.moduleroot(m)
+	basepath = dirname(String(s.file))
+	
+    # file path should always be relative to the
+    # module loads it, unless specified as absolute
+    # path or the module is created interactively
+    if !isabspath(path) && basepath != ""
+        path = joinpath(basepath, path)
     else
-        toplevel_symbol = Symbol("#__toplevel__#")
-        if isdefined(root, toplevel_symbol) # package
-            toplevel = getfield(root, toplevel_symbol)
-        else
-            toplevel = Base.eval(root, :(baremodule $toplevel_symbol; using Base; end))
-        end
-    end
+		path = abspath(path)
+	end
+	
+    loading = Expr(ex.head)
     
-    file_module = load_module(toplevel, root, path)
+    if root === Main
+        file_module_sym = Symbol(path)
+    else
+        file_module_sym = Symbol(relpath(path, pathof(root)))
+    end
+
+    if isdefined(root, file_module_sym)
+        file_module = getfield(root, file_module_sym)
+    else
+        file_module = Base.eval(root, :(module $(file_module_sym); include($path); end))
+    end
 
     for each in ex.args
         each isa Expr || continue
@@ -46,33 +51,6 @@ function from_m(m::Module, path::String, ex::Expr)
         end
     end
     return loading
-end
-
-function load_module(toplevel::Module, root::Module, path::String)
-    if root === Main
-        file_module_sym = Symbol(path)
-    else
-        file_module_sym = Symbol(relpath(path, pathof(root)))
-    end
-
-    if isdefined(toplevel, file_module_sym)
-        file_module = getfield(toplevel, file_module_sym)
-    else
-        file_module = Base.eval(toplevel, :(module $(file_module_sym); end))
-        Base.include(file_module, path)
-    end
-
-    return file_module
-end
-
-function root_module(m::Module)
-    root = parentmodule(m)
-    prev = m
-    while root !== prev
-        prev = root
-        root = parentmodule(root)
-    end
-    return root
 end
 
 end

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -41,10 +41,9 @@ function from_m(m::Module, s::LineNumberNode, path::String, ex::Expr)
         if each.head === :(:) # using/import A: a, b, c
             m_name = each.args[1].args[1]
             m_name === :(.) && error("cannot load relative module from file")
-            push!(loading.args, Expr(:(:), Expr(:., fullname(file_module)..., m_name), each.args[2:end]...) )
-        elseif each.head === :(.) # using/import A, B, C
-            m_name = each.args[1] # module name
-            m_name === :(.) && error("cannot load relative module from file")
+            push!(loading.args, Expr(:(:), Expr(:., fullname(file_module)..., each.args[1].args...), each.args[2:end]...) )
+        elseif each.head === :(.) # using/import A, B.C
+            each.args[1] === :(.) && error("cannot load relative module from file")
             push!(loading.args, Expr(:., fullname(file_module)..., each.args...))
         else
             error("invalid syntax $ex")

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -39,8 +39,7 @@ function from_m(m::Module, s::LineNumberNode, path::String, ex::Expr)
         each isa Expr || continue
 
         if each.head === :(:) # using/import A: a, b, c
-            m_name = each.args[1].args[1]
-            m_name === :(.) && error("cannot load relative module from file")
+            each.args[1].args[1] === :(.) && error("cannot load relative module from file")
             push!(loading.args, Expr(:(:), Expr(:., fullname(file_module)..., each.args[1].args...), each.args[2:end]...) )
         elseif each.head === :(.) # using/import A, B.C
             each.args[1] === :(.) && error("cannot load relative module from file")

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -45,7 +45,7 @@ function from_m(m::Module, s::LineNumberNode, path::String, ex::Expr)
         elseif each.head === :(.) # using/import A, B, C
             m_name = each.args[1] # module name
             m_name === :(.) && error("cannot load relative module from file")
-            push!(loading.args, Expr(:., fullname(file_module)..., m_name))
+            push!(loading.args, Expr(:., fullname(file_module)..., each.args...))
         else
             error("invalid syntax $ex")
         end

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -18,8 +18,8 @@ function from_m(m::Module, s::LineNumberNode, path::String, ex::Expr)
     if !isabspath(path) && basepath != ""
         path = joinpath(basepath, path)
     else
-		path = abspath(path)
-	end
+        path = abspath(path)
+    end
 	
     loading = Expr(ex.head)
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ end
 module wrapper5
 	using FromFile
 	visible = [:foo, :B]
-	invisible = [:bar, :baz, :quux, :A, :B, :C]
+	invisible = [:bar, :baz, :quux, :A, :C]
 	
     @from "file.jl" import A.foo, A.B
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ module wrapper1
 	visible = [:A]
 	invisible = [:foo, :bar, :baz, :quux, :B, :C]
 	
-    @from "test/file.jl" import A
+    @from "file.jl" import A
 end
 
 module wrapper2
@@ -14,7 +14,7 @@ module wrapper2
 	visible = [:foo]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-	@from "test/file.jl" import A: foo
+	@from "file.jl" import A: foo
 end
 
 module wrapper3
@@ -22,7 +22,7 @@ module wrapper3
 	visible = [:foo, :B]
 	invisible = [:bar, :baz, :quux, :A, :C]
 	
-	@from "test/file.jl" import A: foo, B
+	@from "file.jl" import A: foo, B
 end
 
 module wrapper4
@@ -30,7 +30,7 @@ module wrapper4
 	visible = [:foo]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-    @from "test/file.jl" import A.foo
+    @from "file.jl" import A.foo
 end
 
 module wrapper5
@@ -38,7 +38,7 @@ module wrapper5
 	visible = [:foo, :B]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-    @from "test/file.jl" import A.foo, A.B
+    @from "file.jl" import A.foo, A.B
 end
 
 module wrapper6
@@ -46,7 +46,7 @@ module wrapper6
 	visible = [:A, :foo, :B]
 	invisible = [:bar, :baz, :quux, :C]
 	
-	@from "test/file.jl" using A
+	@from "file.jl" using A
 end
 
 module wrapper7
@@ -54,7 +54,7 @@ module wrapper7
 	visible = [:foo]
 	invisible = [:bar, :baz, :quux, :A, :B, :C]
 	
-	@from "test/file.jl" using A: foo
+	@from "file.jl" using A: foo
 end
 
 module wrapper8
@@ -62,7 +62,7 @@ module wrapper8
 	visible = [:foo, :B]
 	invisible = [:bar, :baz, :quux, :A, :C]
 	
-	@from "test/file.jl" using A: foo, B
+	@from "file.jl" using A: foo, B
 end
 
 module wrapper9
@@ -70,7 +70,7 @@ module wrapper9
 	visible = [:A, :C]
 	invisible = [:foo, :bar, :baz, :quux, :B]
 	
-    @from "test/file.jl" import A, C
+    @from "file.jl" import A, C
 end
 
 module wrapper10
@@ -78,7 +78,7 @@ module wrapper10
 	visible = [:foo, :quux, :A, :B, :C]
 	invisible = [:bar, :baz]
 	
-    @from "test/file.jl" using A, C
+    @from "file.jl" using A, C
 end
 
 @testset "Tests from REPL" begin
@@ -103,6 +103,5 @@ end
 	# Make sure that the import modules are where we expect them to be
 	project_path = dirname(dirname(pathof(FromFile)))
 	file_symbol = Symbol(abspath(joinpath(project_path, "test", "file.jl")))
-	@test fullname(wrapper1.A) == (:FromFile, :__toplevel__, file_symbol, :A)
-	@test isdefined(FromFile.__toplevel__, file_symbol)
+	@test fullname(wrapper1.A) == (:Main, file_symbol, :A)
 end


### PR DESCRIPTION
- Fixes for path lookup. #3 has issues in that `pathof(m)` returns `nothing` for submodules.
- Fixes for using `@from` in packages. Neither #3 nor master support this: the issue is that we create modules and then try to `eval` code inside of them, which creates an error:
```Evaluation into the closed module `#__imports__#` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `#__imports__#` with `eval` during precompilation - don't do this.```
- I have copied over the fixes made in #3 related to passing tests.
- Fix for the `from ... import A.B: C` case.

I think #3 should be modified to provide just the CI, as this seems like a simpler approach.