### PR TITLE
Fix edge case when import a module in different ways from the REPL

### DIFF
--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -14,18 +14,17 @@ function from_m(m::Module, s::LineNumberNode, path::String, root_ex::Expr)
     end
     
     all(ex -> ex.head === :using || ex.head === :import, import_exs) || error("expected using/import statement")
-	
-	root = Base.moduleroot(m)
-	basepath = dirname(String(s.file))
-	
+
+    root = Base.moduleroot(m)
+    basepath = dirname(String(s.file))
+
     # file path should always be relative to the
     # module loads it, unless specified as absolute
     # path or the module is created interactively
     if !isabspath(path) && basepath != ""
         path = joinpath(basepath, path)
-    else
-        path = abspath(path)
     end
+    path = abspath(path)
 	
     
     if root === Main


### PR DESCRIPTION
If I'm understanding #27 correctly, then the deduplication doesn't always work in the REPL. In particular, `..` isn't always normalised out.

When loading a module, specified in a file, but whose rootmodule is `Main` -- i.e. the file has been `include`d -- and which uses `@from` with a relative path, then:
- `!isabspath(path)` is `true` as it is a relative path
- `basepath != ""` as the module is specified in a file
- and so the first branch on this `if` is triggered and the path is only `joinpath`d not `abspath`d.
- this hasn't been a big issue so far, because the next `if` block checks whether the rootmodule is `Main`, and in the very common case that it isn't, does a `relpath` that implicitly also normalises out any `..`.
- however if the rootmodule is `Main` then we just use the path as-is.

I think this should fix it.
(+also some funny indentation on some earlier lines.)

This is partly theory-crafting on my part, I've not carefully tested every possible edge case so another pair of eyes would be good @Roger-luo .