### PR TITLE
Add transform to handle aliasing edge-cases

### DIFF
--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -67,6 +67,9 @@ function from_m(m::Module, s::LineNumberNode, path::String, root_ex::Expr)
             elseif each.head === :(.) # using/import A, B.C
                 each.args[1] === :(.) && error("cannot load relative module from file")
                 push!(loading.args, Expr(:., fullname(file_module)..., each.args...))
+            elseif each.head === :as  # import A as B
+                each.args[1].args[1] === :(.) && error("cannot load relative module from file")
+                push!(loading.args, Expr(:as, Expr(:., fullname(file_module)..., each.args[1].args[1]), each.args[2]))
             else
                 error("invalid syntax $ex")
             end

--- a/src/FromFile.jl
+++ b/src/FromFile.jl
@@ -61,15 +61,12 @@ function from_m(m::Module, s::LineNumberNode, path::String, root_ex::Expr)
         for each in ex.args
             each isa Expr || continue
 
-            if each.head === :(:) # using/import A: a, b, c
+            if each.head === :(:) || each.head === :as # using/import A: a, b, c or import A as B
                 each.args[1].args[1] === :(.) && error("cannot load relative module from file")
-                push!(loading.args, Expr(:(:), Expr(:., fullname(file_module)..., each.args[1].args...), each.args[2:end]...) )
+                push!(loading.args, Expr(each.head, Expr(:., fullname(file_module)..., each.args[1].args...), each.args[2:end]...) )
             elseif each.head === :(.) # using/import A, B.C
                 each.args[1] === :(.) && error("cannot load relative module from file")
                 push!(loading.args, Expr(:., fullname(file_module)..., each.args...))
-            elseif each.head === :as  # import A as B
-                each.args[1].args[1] === :(.) && error("cannot load relative module from file")
-                push!(loading.args, Expr(:as, Expr(:., fullname(file_module)..., each.args[1].args[1]), each.args[2]))
             else
                 error("invalid syntax $ex")
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,14 @@ module wrapper12
 	end
 end
 
+module wrapper13
+	using FromFile
+	visible = [:D]
+	invisible = [:foo, :bar, :baz, :quux, :A, :B, :C]
+
+	@from "basic.jl" import A as D
+end
+
 module wrapper_without_import
 	# https://github.com/Roger-luo/FromFile.jl/issues/24
 	using FromFile
@@ -142,7 +150,10 @@ end
 	@test !isdefined(@__MODULE__, :quux)
 	
 	# Check the right things are or aren't there.
-	wrappers = (wrapper1, wrapper2, wrapper3, wrapper4, wrapper5, wrapper6, wrapper7, wrapper8, wrapper9, wrapper10, wrapper11, wrapper12)
+	wrappers = (
+		wrapper1, wrapper2, wrapper3, wrapper4, wrapper5, wrapper6, wrapper7,
+		wrapper8, wrapper9, wrapper10, wrapper11, wrapper12, wrapper13
+	)
 	for wrapper in wrappers
 		for visible in wrapper.visible
 			@eval @test isdefined($wrapper, $(QuoteNode(visible)))


### PR DESCRIPTION
Transforms unsupported expressions of the form `import X as Y` to a valid `using X: X as Y` expression. Also adds appropriate test with exposed `D` symbol.